### PR TITLE
More advanced topics in Python: Add uproot and links to documentation

### DIFF
--- a/python/further_reading.md
+++ b/python/further_reading.md
@@ -4,8 +4,11 @@
 * argsparse, datetime, fnmatch, glob, os, re, sys, subprocess
 
 ## Nice libraries for data analysis
-* numpy, pandas, matplotlib
+* [NumPy](https://numpy.org/)
+* [pandas](https://pandas.pydata.org/docs/)
+* [matplotlib](https://matplotlib.org/)
 
 ## Python and ROOT
-* pyROOT
-* root_numpy
+* pyROOT: Python interface for ROOT
+* [uproot](https://uproot.readthedocs.io/en/latest/index.html): A library for reading data from root files into Python NumPy arrays, Awkward arrays and Pandas dataframes
+* root_numpy (deprecated)


### PR DESCRIPTION
Edit text in chapter "More advanced topics in Python": Add uproot to the list (root_numpy is deprecated). Add links to package documentation and webpages.
