### PR TITLE
Update persistent-screen.md with the `cern-get-keytab` command

### DIFF
--- a/shell-extras/persistent-screen.md
+++ b/shell-extras/persistent-screen.md
@@ -3,7 +3,15 @@
 ### Setting up password-less kerberos token
 
 In order for the kerberos token to be refreshed automatically, it must be possible to do so without a password.
-Therefore, we create a keytab (similar to a private ssh key) on lxplus using the keytab utility. After starting it by typing `ktutil`, type the following three lines into the prompt and confirm the first two steps with your password.
+Therefore, we create a keytab (similar to a private ssh key) on lxplus.
+
+We can do this using
+
+```bash
+cern-get-keytab --keytab USERNAME.keytab --user --login USERNAME
+```
+
+or manually using the keytab utility. After starting it by typing `ktutil`, type the following three lines into the prompt and confirm the first two steps with your password.
 ```bash
 add_entry -password -p USERNAME@CERN.CH -k 1 -e arcfour-hmac-md5
 add_entry -password -p USERNAME@CERN.CH -k 1 -e aes256-cts


### PR DESCRIPTION
Updating the instructions for creating a kerberos keytab for persistent screen or tmux authentication using the newer `cern-get-keytab` instead of the keytab utility, since the latter did not work for me.