### PR TITLE
Adding data analysis libraries

### DIFF
--- a/python/further_reading.md
+++ b/python/further_reading.md
@@ -1,12 +1,16 @@
 # More advanced topics in Python
 
 ## Nice standard libraries
-* argsparse, datetime, fnmatch, glob, os, re, sys, subprocess
+* argsparse, datetime, fnmatch, re, sys, subprocess, pathlib
 
 ## Nice libraries for data analysis
 * [NumPy](https://numpy.org/)
 * [pandas](https://pandas.pydata.org/docs/)
 * [matplotlib](https://matplotlib.org/)
+* [iminuit](https://iminuit.readthedocs.io/en/stable/) for fitting
+* [resample](https://resample.readthedocs.io/en/stable/) for uncertainty estimation with the bootstrap and jackknife
+* [jacobi](https://hdembinski.github.io/jacobi/) for error propagation based on first derivatives
+* [numba-stats](https://github.com/HDembinski/numba-stats) fast implementations of statistical distributions to build statistical models
 
 ## Python and ROOT
 * pyROOT: Python interface for ROOT


### PR DESCRIPTION
Hi, 

I would like to add some libraries to this this. Disclaimer: I am the author of iminuit, resample, jacobi, and numba-stats. 

These libs are foundational for HEP analysis in Python, if you want to work outside of ROOT. iminuit with numba-stats is faster than RooFit and similarly versatile, while being a much more open system. jacobi and resample cover all needs of estimating and propagating statistical uncertainties. iminuit and resample are part of Scikit-HEP. All these libraries have excellent documentation and are of high quality.

I further changed the list of nice standard libraries: pathlib is the modern replacement for direct calls to the os and glob modules.