### PR TITLE
Fix inclusion of plausible script

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -46,7 +46,9 @@ nbsphinx_timeout = 60*20
 # FIXME: This should be removed
 # nbsphinx_execute = 'never'
 
-_PLAUSIBLE_SNIPPET = '<script defer data-domain="hepsoftwarefoundation.org" src="https://views.scientific-python.org/js/script.js"></script>'
 
 def setup(app):
-    app.add_js_file(None, body=_PLAUSIBLE_SNIPPET)
+    app.add_js_file(
+        "https://views.scientific-python.org/js/script.js",
+        **{"defer": "defer", "data-domain": "hepsoftwarefoundation.org"}
+    )


### PR DESCRIPTION
Currently it puts 

```
        <script><script defer data-domain="hepsoftwarefoundation.org" src="https://views.scientific-python.org/js/script.js"></script></script>
```

I hope this will fix it, but full disclaimer, I didn't test locally (because I didn't get it to build)