### PR TITLE
doc: fix build status badge in title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Analysis essentials [![Build Status]([https://github.com/hsf-training/analysis-essentials/actions/workflows/build.yml/badge.svg](https://github.com/hsf-training/analysis-essentials/actions/workflows/build.yml/badge.svg))](https://github.com/hsf-training/analysis-essentials/actions/workflows/build.yml/badge.svg) [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/hsf-training/analysis-essentials/master)
+# Analysis essentials [![Build Status](https://github.com/hsf-training/analysis-essentials/actions/workflows/build.yml/badge.svg)](https://github.com/hsf-training/analysis-essentials/actions/workflows/build.yml/badge.svg) [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/hsf-training/analysis-essentials/master)
 
 
 This is the source material for the [analysis essentials website][website], a


### PR DESCRIPTION
This fixes the image in the title, both here on github and on rtd. 
![image](https://github.com/hsf-training/analysis-essentials/assets/4656391/10ea1db2-fd4a-40ad-b155-10ae36fe2b36)
