### PR TITLE
Patch 1

### DIFF
--- a/git/11-ci.md
+++ b/git/11-ci.md
@@ -39,7 +39,8 @@ my_first_job:
 This creates a single job named `my_first_job` and the `image:` key defines a
 [docker image](https://www.freecodecamp.org/news/a-beginner-friendly-introduction-to-containers-vms-and-docker-79a9e3e119b/)
 which is used the define the environment that is used to run the job. In this case we use an
-[official CERN AlmaLinux 9 image](https://linux.web.cern.ch/dockerimages/).
+[official CERN AlmaLinux 9 image](https://gitlab.cern.ch:/linuxsupport/alma9-base/container_registry).
+More images are listed at the [documentation pages](https://linux.web.cern.ch/dockerimages/) for linux at CERN.
 The `script:` key then defines one or more commands which are executed
 sequentially. If any of the command return a non-zero exit code the execution
 stops and the "build" is marked as failed.

--- a/git/11-ci.md
+++ b/git/11-ci.md
@@ -29,7 +29,7 @@ with each job having it's own environment. A minimal example of this file is:
 
 ```yaml
 my_first_job:
-    image: gitlab-registry.cern.ch/ci-tools/ci-worker:cc7
+    image: gitlab-registry.cern.ch/linuxsupport/alma9-base
     script:
         - python -c 'import this'
         - echo "My first CI produced file" > output.txt
@@ -39,7 +39,7 @@ my_first_job:
 This creates a single job named `my_first_job` and the `image:` key defines a
 [docker image](https://www.freecodecamp.org/news/a-beginner-friendly-introduction-to-containers-vms-and-docker-79a9e3e119b/)
 which is used the define the environment that is used to run the job. In this case we use an
-[official CERN CentOS 7 image](https://gitlab.cern.ch/ci-tools/ci-worker/container_registry).
+[official CERN AlmaLinux 9 image](https://linux.web.cern.ch/dockerimages/).
 The `script:` key then defines one or more commands which are executed
 sequentially. If any of the command return a non-zero exit code the execution
 stops and the "build" is marked as failed.


### PR DESCRIPTION
Update recommended image for CI.

cc7 is getting [deprecated](https://linux.web.cern.ch/which/) at CERN,
Page of documentation that list images is https://linux.web.cern.ch/dockerimages/
