### PR TITLE
Update README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To install `Conda`/`mamba` you will need to do the following:
  - Install `mamba` according to the instructions [here](https://github.com/conda-forge/miniforge#install)
  - To add `mamba`/`conda` to your shell, follow the instructions after the installation and execute
 ```bash
-mamba init
+mamba shell init
 ```
 
 


### PR DESCRIPTION
changed line 40:
mamba init -> mamba shell init
reason:
old command, on running gives the error in linux as: mamba init
The following argument was not expected: init
Run with --help for more information.

Tested with ubuntu 22
